### PR TITLE
Make credentials configurable

### DIFF
--- a/src/rabbit_tracing_consumer.erl
+++ b/src/rabbit_tracing_consumer.erl
@@ -28,6 +28,9 @@
                      vhost, username, channel, routing_keys, routed_queues,
                      properties, payload}).
 
+-define(DEFAULT_USERNAME, <<"guest">>).
+-define(DEFAULT_PASSWORD, <<"guest">>).
+
 -define(X, <<"amq.rabbitmq.trace">>).
 -define(MAX_BUF, 100).
 
@@ -47,9 +50,15 @@ init(Args) ->
     process_flag(trap_exit, true),
     Name = pget(name, Args),
     VHost = pget(vhost, Args),
+    Username = rabbit_tracing_util:coerce_env_value(username,
+        rabbit_misc:get_env(rabbitmq_tracing, username, ?DEFAULT_USERNAME)),
+    Password = rabbit_tracing_util:coerce_env_value(password,
+        rabbit_misc:get_env(rabbitmq_tracing, password, ?DEFAULT_PASSWORD)),
     MaxPayload = pget(max_payload_bytes, Args, unlimited),
     {ok, Conn} = amqp_connection:start(
-                   #amqp_params_direct{virtual_host = VHost}),
+                   #amqp_params_direct{virtual_host = VHost,
+                                       username = Username,
+                                       password = Password}),
     link(Conn),
     {ok, Ch} = amqp_connection:open_channel(Conn),
     link(Ch),

--- a/src/rabbit_tracing_util.erl
+++ b/src/rabbit_tracing_util.erl
@@ -1,0 +1,13 @@
+-module(rabbit_tracing_util).
+
+-export([to_binary/1, coerce_env_value/2]).
+
+%% TODO: move to rabbit_common
+%% TODO: move to rabbit_common
+coerce_env_value(username, Val) -> to_binary(Val);
+coerce_env_value(password, Val) -> to_binary(Val);
+coerce_env_value(_,        Val) -> Val.
+
+%% TODO: move to rabbit_common
+to_binary(Val) when is_list(Val) -> list_to_binary(Val);
+to_binary(Val)                   -> Val.

--- a/src/rabbitmq_tracing.app.src
+++ b/src/rabbitmq_tracing.app.src
@@ -4,5 +4,7 @@
   {modules, []},
   {registered, []},
   {mod, {rabbit_tracing_app, []}},
-  {env, [{directory, "/var/tmp/rabbitmq-tracing"}]},
+  {env, [{directory, "/var/tmp/rabbitmq-tracing"},
+         {username, <<"guest">>},
+         {password, <<"guest">>}]},
   {applications, [kernel, stdlib, rabbit, rabbitmq_management]}]}.

--- a/test/src/rabbit_tracing_test.erl
+++ b/test/src/rabbit_tracing_test.erl
@@ -85,8 +85,8 @@ tracing_validation_test() ->
     ok.
 
 %%---------------------------------------------------------------------------
-%% Below is copypasta from rabbit_mgmt_test_http, it's not obvious how
-%% to share that given the build system.
+%% TODO: Below is copied from rabbit_mgmt_test_http,
+%%       should be moved into a shared library
 
 http_get(Path) ->
     http_get(Path, ?OK).
@@ -103,29 +103,11 @@ http_get(Path, User, Pass, CodeExp) ->
 http_put(Path, List, CodeExp) ->
     http_put_raw(Path, format_for_upload(List), CodeExp).
 
-http_put(Path, List, User, Pass, CodeExp) ->
-    http_put_raw(Path, format_for_upload(List), User, Pass, CodeExp).
-
-http_post(Path, List, CodeExp) ->
-    http_post_raw(Path, format_for_upload(List), CodeExp).
-
-http_post(Path, List, User, Pass, CodeExp) ->
-    http_post_raw(Path, format_for_upload(List), User, Pass, CodeExp).
-
 format_for_upload(List) ->
     iolist_to_binary(mochijson2:encode({struct, List})).
 
 http_put_raw(Path, Body, CodeExp) ->
     http_upload_raw(put, Path, Body, "guest", "guest", CodeExp).
-
-http_put_raw(Path, Body, User, Pass, CodeExp) ->
-    http_upload_raw(put, Path, Body, User, Pass, CodeExp).
-
-http_post_raw(Path, Body, CodeExp) ->
-    http_upload_raw(post, Path, Body, "guest", "guest", CodeExp).
-
-http_post_raw(Path, Body, User, Pass, CodeExp) ->
-    http_upload_raw(post, Path, Body, User, Pass, CodeExp).
 
 http_upload_raw(Type, Path, Body, User, Pass, CodeExp) ->
     {ok, {{_HTTP, CodeAct, _}, Headers, ResBody}} =


### PR DESCRIPTION
Alternatively we could try reusing management credentials; however,
management UI is undergoing major changes and now is not a good time.

Fixes #1 (to the extent it can be done with upcoming changes to the management plugin).
