### PR TITLE
Set bounded timeout for OTP workers

### DIFF
--- a/src/rabbit_tracing_consumer_sup.erl
+++ b/src/rabbit_tracing_consumer_sup.erl
@@ -30,5 +30,5 @@ start_link(Args) -> supervisor2:start_link(?MODULE, Args).
 init(Args) ->
     {ok, {{one_for_one, 3, 10},
           [{consumer, {rabbit_tracing_consumer, start_link, [Args]},
-            transient, ?MAX_WAIT, worker,
+            transient, ?WORKER_WAIT, worker,
             [rabbit_tracing_consumer]}]}}.

--- a/src/rabbit_tracing_sup.erl
+++ b/src/rabbit_tracing_sup.erl
@@ -34,7 +34,7 @@ start_child(Id, Args) ->
     supervisor:start_child(
       ?SUPERVISOR,
       {Id, {rabbit_tracing_consumer_sup, start_link, [Args]},
-       temporary, ?MAX_WAIT, supervisor,
+       temporary, ?SUPERVISOR_WAIT, supervisor,
        [rabbit_tracing_consumer_sup]}).
 
 stop_child(Id) ->
@@ -46,5 +46,5 @@ stop_child(Id) ->
 
 init([]) -> {ok, {{one_for_one, 3, 10},
                   [{traces, {rabbit_tracing_traces, start_link, []},
-                    transient, ?MAX_WAIT, worker,
+                    transient, ?WORKER_WAIT, worker,
                     [rabbit_tracing_traces]}]}}.


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT` for workers and with `SUPERVISOR_WAIT` for supervisors.
